### PR TITLE
WIP: Attempting to test against conda-build master and the latest released version of conda-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.py[co]
 __pycache__
 *.egg-info
+.cache/
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,18 @@ env:
        # Secure BINSTAR_TOKEN for pelson/conda-build-all which can write to Obvious-CI-tests
        - secure: Dz1ZWH583kXz725IUSU32en048qGnweQZqrONg9CmDZuBwb3hE6CZ/qpXlKxLD6pqrV1fRJLxhoJo+7wS828GVdg5nfGdw1TyJdSsIDVjXjVMKRGx4fJagodE83E1sjBgyFrh7z/giHmT65+mExS4lzGBM56fOoVrNk2+WTF31xsPAMimF1qLvNA9vBpOExjpxaugFaZwRdhWqYMHT2RtLUnFPjtOWvj0Q0MlLUjoXznTRTl6YLN2jyRbEg42R62goXgp6hAVQ7Dn/OfV4ax8pofiStwmMSFdyfx3Y60xEGAwopO5DzYNVqwO4t2lvoIq9jkQH3RQCtNjEZ8KcewuLym+RapRcidAwUwhaW3K7IDqbiSmaD5x6wgwZripfl+LHcWgXup0gK/eYVwrVh3hsa6ATwpc7/qMMSR1AEhHooUv6bNzASSeZmiBh/2gvq7Kob+WAa+RgwdCc1wOGsmWdicvLWSTwvnriHDrUYqS/uixV5A7C+o8VsnQC2Lcx24pO50NBhSSBpp73yHNmaQIwwEmxDEBUiFqtYz/V0peck+UQMHi+sgR/V8xB2dVQiyxaZI3/UAGtBqf3qtOGRiLQ3kFW8DAbi/2t19xk8c0FLf17ELTxURiFjTPQ78qmDDaI6MmK2bhi9IjTFBLLJU4m2ziW2l0MrTm4w3dwU7kls=
     matrix:
-        - PYTHON=2.7
-        - PYTHON=3.4
+      include:
         - PYTHON=3.5
           CONDA_BUILD_ALL_TEST_ANACONDA_CLOUD=1
+
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+
+CONDA_BUILD:
+  - devel
+  - tagged
 
 install:
     - mkdir -p ${HOME}/cache/pkgs
@@ -29,10 +37,15 @@ install:
     - if [ -z "$BINSTAR_TOKEN"  -a -n "$CONDA_BUILD_ALL_TEST_ANACONDA_CLOUD" ]; then
          echo "BINSTAR_TOKEN is not defined, some of the intergation tests have been disabled. These will be re-enabled when merged." &&
          export CONDA_BUILD_ALL_TEST_ANACONDA_CLOUD=0;
-      fi 
+      fi
 
     # Now do the things we need to do to install it.
     - conda install --file requirements.txt nose mock python=${PYTHON} --yes --quiet
+    # install the master branch of conda-build
+    - if [[ CONDA_BUILD == 'devel' ]]; then
+        conda remove conda_build --yes;
+        pip install https://github.com/conda/conda-build/zipball/master#egg=conda-build;
+      fi;
     - python setup.py install
     - mkdir not_the_source_root && cd not_the_source_root
 


### PR DESCRIPTION
I could have done this by turning on travis for my fork, but this is easier.  
I'm also doing this because I think I already found an API change in conda-build 
master that breaks `resolved_distribution.py`. Let's see if the test suite on conda-build-all hits it.
If not, I'll make a test to expose it