### PR TITLE
Cease converting the version to an integer for perl and R.

### DIFF
--- a/conda_build_all/resolved_distribution.py
+++ b/conda_build_all/resolved_distribution.py
@@ -24,10 +24,11 @@ def setup_vn_mtx_case(case):
     orig_perl = conda_build.config.config.CONDA_PERL
 
     for pkg, version in case:
-        version = int(version.replace('.', ''))
         if pkg == 'python':
+            version = int(version.replace('.', ''))
             conda_build.config.config.CONDA_PY = version
         elif pkg == 'numpy':
+            version = int(version.replace('.', ''))
             conda_build.config.config.CONDA_NPY = version
         elif pkg == 'perl':
             conda_build.config.config.CONDA_PERL = version

--- a/conda_build_all/tests/unit/test_resolved_distribution.py
+++ b/conda_build_all/tests/unit/test_resolved_distribution.py
@@ -7,7 +7,8 @@ import textwrap
 import conda_build.config
 from conda_build.metadata import MetaData
 
-from conda_build_all.resolved_distribution import ResolvedDistribution
+from conda_build_all.resolved_distribution import (ResolvedDistribution,
+                                                   setup_vn_mtx_case)
 from conda_build_all.tests.unit import RecipeCreatingUnit
 from conda_build_all.tests.unit.dummy_index import DummyIndex, DummyPackage
 
@@ -101,6 +102,20 @@ class Test_BakedDistribution_resolve_all(RecipeCreatingUnit):
                                        extra_conditions=['python 2.6.*|>=3'])
         ids = [dist.build_id() for dist in resolved]
         self.assertEqual(ids, ['py26_0', 'py35_0'])
+
+
+class Test_setup_vn_mtx_case(unittest.TestCase):
+    def test_perl_case(self):
+        with setup_vn_mtx_case([('perl', '9.10.11.12'), ('numpy', '1.23'),
+                                ('python', '2.7'), ('r', '4.5.6')]):
+            self.assertEqual(conda_build.config.config.CONDA_PERL,
+                             '9.10.11.12')
+            self.assertEqual(conda_build.config.config.CONDA_NPY,
+                             123)
+            self.assertEqual(conda_build.config.config.CONDA_PY,
+                             27)
+            self.assertEqual(conda_build.config.config.CONDA_R,
+                             '4.5.6')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Finishes off the job in #27 after seeing some real use in https://github.com/conda-forge/staged-recipes/pull/237.