### PR TITLE
RFC: Utilize new api on conda_build.build:build

### DIFF
--- a/conda_build_all/build.py
+++ b/conda_build_all/build.py
@@ -29,7 +29,7 @@ def build(meta, test=True):
         meta.check_fields()
         if os.path.exists(conda_build.config.config.info_dir):
             shutil.rmtree(conda_build.config.config.info_dir)
-        build_module.build(meta, post=None, **kwd)
+        build_module.build(meta, post=None, need_source_download=True, **kwd)
         if test:
             build_module.test(meta, **kwd)
         return meta


### PR DESCRIPTION
I am not entirely sure where the information lives that would tell me if we
need to download the source or not.  I do know that just forcing
need_source_download=True fixes one recipe that is affected by
conda-forge/staged-recipes#613. Hopefully it fixes all of them.

Closes conda-forge/staged-recipes#613 after this (or a similar fix) is merged
and a new tag is pushed and built.

To test this in your staged-recipe, modify staged-recipes/scripts/run_docker_build.sh
and don't conda install conda-build-all, but instead:

```bash
conda install mock
pip install https://github.com/ericdill/conda-build-all/zipball/download-the-source/#egg=conda_build_all
```