### PR TITLE
De-duplicate a couple of test names

### DIFF
--- a/conda_build_all/tests/unit/test_artefact_destination.py
+++ b/conda_build_all/tests/unit/test_artefact_destination.py
@@ -75,7 +75,7 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
         # Nothing happens, we just get a message.
         self.logger.info.assert_called_once_with('Nothing to be done for a - it is already on sentinel.owner/sentinel.channel.')
 
-    def test_already_available_not_just_built(self):
+    def test_already_available_just_built(self):
         client, owner, channel = [mock.sentinel.client, mock.sentinel.owner,
                                   mock.sentinel.channel]
         ad = AnacondaClientChannelDest(mock.sentinel.token, owner, channel)

--- a/conda_build_all/tests/unit/test_version_matrix.py
+++ b/conda_build_all/tests/unit/test_version_matrix.py
@@ -363,7 +363,7 @@ class Test_filter_cases(CasesTestCase):
                  [self.item['py35']])
         self.assertEqual(tuple(filter_cases(cases, ['python >=3', 'python <=3.4'])), cases[1:2])
 
-    def test_multiple_filter(self):
+    def test_multiple_filter_with_numpy(self):
         cases = ([self.item['py26'], self.item['np110']],
                  [self.item['py34'], self.item['np19']],
                  [self.item['py35'], self.item['np110']])


### PR DESCRIPTION
In preparation for a separate pull request (coming soon) to allow cross-owner copying I noticed that there were a couple of test names that were accidentally duplicated. This PR fixes those.