### PR TITLE
Add cross-owner package copying

### DIFF
--- a/conda_build_all/artefact_destination.py
+++ b/conda_build_all/artefact_destination.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import subprocess
 from argparse import Namespace
+import posixpath as urlpath
 
 import binstar_client.utils
 import binstar_client
@@ -116,6 +117,6 @@ class AnacondaClientChannelDest(ArtefactDestination):
         elif not just_built:
             # The distribution already existed, but not under the target owner.
             if 'http://' in built_dist_path or 'https://' in built_dist_path:
-                source_owner = built_dist_path.rsplit('/', 3)[-3]
+                source_owner = urlpath.basename(urlpath.dirname(built_dist_path.rstrip('/')))
                 inspect_binstar.copy_distribution_to_owner(self._cli, source_owner, self.owner, meta,
                                                            channel=self.channel)

--- a/conda_build_all/artefact_destination.py
+++ b/conda_build_all/artefact_destination.py
@@ -116,5 +116,6 @@ class AnacondaClientChannelDest(ArtefactDestination):
         elif not just_built:
             # The distribution already existed, but not under the target owner.
             if 'http://' in built_dist_path or 'https://' in built_dist_path:
-                raise NotImplementedError('cross owner copying not yet implemented.')
-
+                source_owner = built_dist_path.rsplit('/', 3)[-3]
+                inspect_binstar.copy_distribution_to_owner(self._cli, source_owner, self.owner, meta,
+                                                           channel=self.channel)

--- a/conda_build_all/inspect_binstar.py
+++ b/conda_build_all/inspect_binstar.py
@@ -46,10 +46,22 @@ def distribution_exists_on_channel(binstar_cli, owner, metadata, channel='main')
 def add_distribution_to_channel(binstar_cli, owner, metadata, channel='main'):
     """
     Add a(n already existing) distribution on binstar to another channel.
-    
+
     Note - the addition is done based on name and version - no build strings etc.
     so if you have a foo-0.1-np18 and foo-0.1-np19 *both* will be added to the channel.
-    
+
     """
     package_fname = '{}/{}.tar.bz2'.format(conda.config.subdir, metadata.dist())
     binstar_cli.add_channel(channel, owner, metadata.name(), metadata.version())#filename=package_fname)
+
+
+def copy_distribution_to_owner(binstar_cli, source_owner, dest_owner,
+                               metadata, channel='main'):
+    """
+    Copy an already existing distribution from one owner to another on
+    anaconda.
+    """
+    package_fname = '{}/{}.tar.bz2'.format(conda.config.subdir, metadata.dist())
+    binstar_cli.copy(source_owner, metadata.name(), metadata.version(),
+                     basename=package_fname, to_owner=dest_owner,
+                     to_channel=channel)

--- a/conda_build_all/tests/integration/test_inspect_binstar.py
+++ b/conda_build_all/tests/integration/test_inspect_binstar.py
@@ -80,9 +80,6 @@ class Test(RecipeCreatingUnit):
                                 package:
                                     name: conda-build-all
                                     version: 0.12.0
-                                build:
-                                    script: python setup.py install --single-version-externally-managed --record=record.txt
-
                                 """)
         copy_distribution_to_owner(CLIENT, 'conda-forge', OWNER, meta2, channel='main')
         self.assertTrue(distribution_exists_on_channel(CLIENT, OWNER, meta2))

--- a/conda_build_all/tests/integration/test_inspect_binstar.py
+++ b/conda_build_all/tests/integration/test_inspect_binstar.py
@@ -7,7 +7,8 @@ from argparse import Namespace
 from conda_build_all.build import build, upload
 from conda_build_all.inspect_binstar import (distribution_exists,
                                              distribution_exists_on_channel,
-                                             add_distribution_to_channel)
+                                             add_distribution_to_channel,
+                                             copy_distribution_to_owner)
 from conda_build_all.tests.integration.test_builder import RecipeCreatingUnit
 
 
@@ -73,6 +74,18 @@ class Test(RecipeCreatingUnit):
         add_distribution_to_channel(CLIENT, OWNER, meta, channel='main')
         # Check that the distribution has been added.
         self.assertTrue(distribution_exists_on_channel(CLIENT, OWNER, meta, channel='main'))
+
+        # Add the meta for a recipe known to exist on conda-forge
+        meta2 = self.write_meta('conda_build_all', """
+                                package:
+                                    name: conda-build-all
+                                    version: 0.12.0
+                                build:
+                                    script: python setup.py install --single-version-externally-managed --record=record.txt
+
+                                """)
+        copy_distribution_to_owner(CLIENT, 'conda-forge', OWNER, meta2, channel='main')
+        self.assertTrue(distribution_exists_on_channel(CLIENT, OWNER, meta2))
 
 
 if __name__ == '__main__':

--- a/conda_build_all/tests/unit/test_artefact_destination.py
+++ b/conda_build_all/tests/unit/test_artefact_destination.py
@@ -92,11 +92,14 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
         ad = AnacondaClientChannelDest(mock.sentinel.token, owner, channel)
         ad._cli = client
         meta = DummyPackage('a', '2.1.0')
-        for url in ['http://foo.bar/',
-                    'https://foo.bar/wibble']:
+        source_owner = 'fake_owner'
+        # The osx-64 subdirectory at the end of the URL is not important to the test.
+        for url in ['http://foo.bar/{}/osx-64/'.format(source_owner),
+                    'https://foo.bar/wibble/{}/osx-64/'.format(source_owner)]:
             with self.dist_exists_setup(on_owner=False, on_channel=False):
-                with self.assertRaises(NotImplementedError):
+                with mock.patch('conda_build_all.inspect_binstar.copy_distribution_to_owner') as copy:
                     ad.make_available(meta, url, just_built=False)
+            copy.assert_called_once_with(ad._cli, source_owner, owner, meta, channel=channel)
 
     def test_from_spec_owner(self):
         spec = 'testing'

--- a/conda_build_all/tests/unit/test_artefact_destination.py
+++ b/conda_build_all/tests/unit/test_artefact_destination.py
@@ -95,7 +95,8 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
         source_owner = 'fake_owner'
         # The osx-64 subdirectory at the end of the URL is not important to the test.
         for url in ['http://foo.bar/{}/osx-64/'.format(source_owner),
-                    'https://foo.bar/wibble/{}/osx-64/'.format(source_owner)]:
+                    'https://foo.bar/wibble/{}/osx-64/'.format(source_owner),
+                    'https://foo.bar/wibble/{}/osx-64'.format(source_owner)]:
             with self.dist_exists_setup(on_owner=False, on_channel=False):
                 with mock.patch('conda_build_all.inspect_binstar.copy_distribution_to_owner') as copy:
                     ad.make_available(meta, url, just_built=False)


### PR DESCRIPTION
This PR adds the ability to copy a package from one owner to another on anaconda.org. I've changed  the unit test for this case appropriately and took a shot at adding an integration test for the new function I added in `inspect_binstar`.

There one aspect of the changes I made that I don't like, will make a line comment in a moment.