### PR TITLE
Handle full versioned python special cases.

### DIFF
--- a/conda_build_all/tests/unit/test_version_matrix.py
+++ b/conda_build_all/tests/unit/test_version_matrix.py
@@ -29,9 +29,9 @@ class Test_special_case_version_matrix(unittest.TestCase):
         self.assertEqual(r, set([()]))
 
     def test_python_itself(self):
-        a = DummyPackage('python', version="abc")
+        a = DummyPackage('python', version="a.b.c")
         r = special_case_version_matrix(a, self.index)
-        self.assertEqual(r, set(((('python', 'abc'),),
+        self.assertEqual(r, set(((('python', 'a.b'),),
                                 ))
                          )
 

--- a/conda_build_all/version_matrix.py
+++ b/conda_build_all/version_matrix.py
@@ -238,7 +238,7 @@ def special_case_version_matrix(meta, index):
     # version. This comes down to the odd decision in
     # https://github.com/conda/conda-build/commit/3dddeaf3cf5e85369e28c8f96e24c2dd655e36f0.
     if meta.name() == 'python' and not cases:
-        cases.add((('python', meta.version()),))
+        cases.add((('python', '.'.join(meta.version().split('.', 2)[:2])),))
 
     # Put an empty case in to allow simple iteration of the results.
     if not cases:


### PR DESCRIPTION
I was getting an error when building python 2.7.11 (conda-build was expanding to `2.7.1.1`).