### PR TITLE
changes to support conda-build 2.0's new config

### DIFF
--- a/conda-build-all.recipe/meta.yaml
+++ b/conda-build-all.recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set data = load_setuptools() %}
+{% set data = load_setup_py_data() %}
 
 package:
     name: conda-build-all

--- a/conda_build_all/tests/integration/test_builder.py
+++ b/conda_build_all/tests/integration/test_builder.py
@@ -5,6 +5,7 @@ import tempfile
 import textwrap
 import unittest
 
+import conda_build.api
 from conda_build.metadata import MetaData
 
 from conda_build_all.resolved_distribution import ResolvedDistribution
@@ -34,9 +35,10 @@ class RecipeCreatingUnit(unittest.TestCase):
         recipe_dir = os.path.join(self.recipes_root_dir, recipe_dir_name)
         if not os.path.exists(recipe_dir):
             os.makedirs(recipe_dir)
-        with open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fh:
+        recipe_file = os.path.join(recipe_dir, 'meta.yaml')
+        with open(recipe_file, 'w') as fh:
             fh.write(textwrap.dedent(spec))
-        return MetaData(recipe_dir)
+        return MetaData(recipe_file)
 
 
 class Test_build(RecipeCreatingUnit):
@@ -48,7 +50,7 @@ class Test_build(RecipeCreatingUnit):
                     """)
         pkg1_resolved = ResolvedDistribution(pkg1, (()))
         builder = Builder(None, None, None, None, None)
-        r = builder.build(pkg1_resolved)
+        r = builder.build(pkg1_resolved, conda_build.api.Config())
         self.assertTrue(os.path.exists(r))
         self.assertEqual(os.path.abspath(r), r)
         self.assertEqual(os.path.basename(r), 'pkg1-1.0-0.tar.bz2')
@@ -68,7 +70,7 @@ class Test_build(RecipeCreatingUnit):
                     """)
         pkg1_resolved = ResolvedDistribution(pkg1, (['python', '3.5'], ['numpy', '1.11']))
         builder = Builder(None, None, None, None, None)
-        r = builder.build(pkg1_resolved)
+        r = builder.build(pkg1_resolved, conda_build.api.Config())
         self.assertTrue(os.path.exists(r))
         self.assertEqual(os.path.abspath(r), r)
         self.assertEqual(os.path.basename(r), 'pkg1-1.0-np111py35_0.tar.bz2')
@@ -192,7 +194,7 @@ class Test_compute_build_distros(RecipeCreatingUnit):
                     """)]
         builder = Builder(None, None, None, None, None)
         index = {}
-        distributions = builder.compute_build_distros(index, metas)
+        distributions = builder.compute_build_distros(index, metas, conda_build.api.Config())
         expected = ['python-2.7.0-0', 'python-3.3.0-0', 'python-3.4.24-0',
                     'python-3.5.2-1',
                     'numpy-1.10-py27_0', 'numpy-1.10-py34_0', 'numpy-1.10-py35_0',

--- a/conda_build_all/tests/unit/__init__.py
+++ b/conda_build_all/tests/unit/__init__.py
@@ -20,4 +20,4 @@ class RecipeCreatingUnit(unittest.TestCase):
     def write_meta(self, spec):
         with open(os.path.join(self.recipe_dir, 'meta.yaml'), 'w') as fh:
             fh.write(textwrap.dedent(spec))
-        return MetaData(os.path.join(self.recipe_dir, 'meta.yaml'))
+        return MetaData(os.path.join(self.recipe_dir))

--- a/conda_build_all/tests/unit/__init__.py
+++ b/conda_build_all/tests/unit/__init__.py
@@ -20,5 +20,4 @@ class RecipeCreatingUnit(unittest.TestCase):
     def write_meta(self, spec):
         with open(os.path.join(self.recipe_dir, 'meta.yaml'), 'w') as fh:
             fh.write(textwrap.dedent(spec))
-        return MetaData(self.recipe_dir)
-
+        return MetaData(os.path.join(self.recipe_dir, 'meta.yaml'))

--- a/conda_build_all/tests/unit/dummy_index.py
+++ b/conda_build_all/tests/unit/dummy_index.py
@@ -2,7 +2,12 @@ import collections
 import os
 
 from conda_build.index import write_repodata
-import conda_build.api
+try:
+    import conda_build.api
+    extra_config = False
+except ImportError:
+    import conda_build
+    extra_config = True
 import conda.config
 
 
@@ -64,7 +69,10 @@ class DummyIndex(dict):
         channel_subdir = os.path.join(dest, conda.config.subdir)
         if not os.path.exists(channel_subdir):
             os.mkdir(channel_subdir)
-        write_repodata({'packages': self, 'info': {}}, channel_subdir, conda_build.api.Config())
+        if hasattr(conda_build, 'api'):
+            write_repodata({'packages': self, 'info': {}}, channel_subdir, conda_build.api.Config())
+        else:
+            write_repodata({'packages': self, 'info': {}}, channel_subdir)
 
         return channel_subdir
 

--- a/conda_build_all/tests/unit/dummy_index.py
+++ b/conda_build_all/tests/unit/dummy_index.py
@@ -2,6 +2,7 @@ import collections
 import os
 
 from conda_build.index import write_repodata
+import conda_build.api
 import conda.config
 
 
@@ -63,7 +64,7 @@ class DummyIndex(dict):
         channel_subdir = os.path.join(dest, conda.config.subdir)
         if not os.path.exists(channel_subdir):
             os.mkdir(channel_subdir)
-        write_repodata({'packages': self, 'info': {}}, channel_subdir)
+        write_repodata({'packages': self, 'info': {}}, channel_subdir, conda_build.api.Config())
 
         return channel_subdir
 

--- a/conda_build_all/tests/unit/test_builder.py
+++ b/conda_build_all/tests/unit/test_builder.py
@@ -1,11 +1,7 @@
 import os
-import shutil
-import tempfile
 import unittest
-import textwrap
 
-import conda_build.config
-from conda_build.metadata import MetaData
+import conda_build.api
 
 from conda_build_all.builder import list_metas
 from conda_build_all.tests.integration.test_builder import RecipeCreatingUnit
@@ -96,10 +92,11 @@ class Test_sort_dependency_order(RecipeCreatingUnit):
         # we know that we either have to resolve all dependencies up-front,
         # or simply ignore all selectors when dealing with sort order (but
         # emphatically not when building!).
+        config = conda_build.api.Config()
 
         metas = list_metas(self.recipes_root_dir)
         from conda_build_all.builder import sort_dependency_order
-        names = [m.name() for m in sort_dependency_order(metas)]
+        names = [m.name() for m in sort_dependency_order(metas, config)]
         self.assertEqual(names, ['c', 'a', 'b'])
 
  

--- a/conda_build_all/tests/unit/test_builder.py
+++ b/conda_build_all/tests/unit/test_builder.py
@@ -1,7 +1,10 @@
 import os
 import unittest
 
-import conda_build.api
+try:
+    import conda_build.api
+except ImportError:
+    import conda_build.config
 
 from conda_build_all.builder import list_metas
 from conda_build_all.tests.integration.test_builder import RecipeCreatingUnit
@@ -92,7 +95,10 @@ class Test_sort_dependency_order(RecipeCreatingUnit):
         # we know that we either have to resolve all dependencies up-front,
         # or simply ignore all selectors when dealing with sort order (but
         # emphatically not when building!).
-        config = conda_build.api.Config()
+        if hasattr(conda_build, 'api'):
+            config = conda_build.api.Config()
+        else:
+            config = conda_build.config.config
 
         metas = list_metas(self.recipes_root_dir)
         from conda_build_all.builder import sort_dependency_order

--- a/conda_build_all/tests/unit/test_resolved_distribution.py
+++ b/conda_build_all/tests/unit/test_resolved_distribution.py
@@ -106,16 +106,12 @@ class Test_BakedDistribution_resolve_all(RecipeCreatingUnit):
 
 class Test_setup_vn_mtx_case(unittest.TestCase):
     def test_perl_case(self):
-        with setup_vn_mtx_case([('perl', '9.10.11.12'), ('numpy', '1.23'),
-                                ('python', '2.7'), ('r', '4.5.6')]):
-            self.assertEqual(conda_build.config.config.CONDA_PERL,
-                             '9.10.11.12')
-            self.assertEqual(conda_build.config.config.CONDA_NPY,
-                             123)
-            self.assertEqual(conda_build.config.config.CONDA_PY,
-                             27)
-            self.assertEqual(conda_build.config.config.CONDA_R,
-                             '4.5.6')
+        config = setup_vn_mtx_case([('perl', '9.10.11.12'), ('numpy', '1.23'),
+                                    ('python', '2.7'), ('r', '4.5.6')])
+        self.assertEqual(config.CONDA_PERL, '9.10.11.12')
+        self.assertEqual(config.CONDA_NPY, 123)
+        self.assertEqual(config.CONDA_PY, 27)
+        self.assertEqual(config.CONDA_R, '4.5.6')
 
 
 if __name__ == '__main__':

--- a/conda_build_all/tests/unit/test_resolved_distribution.py
+++ b/conda_build_all/tests/unit/test_resolved_distribution.py
@@ -4,7 +4,10 @@ import tempfile
 import unittest
 import textwrap
 
-import conda_build.config
+try:
+    import conda_build.api
+except ImportError:
+    import conda_build.config
 from conda_build.metadata import MetaData
 
 from conda_build_all.resolved_distribution import (ResolvedDistribution,
@@ -106,12 +109,24 @@ class Test_BakedDistribution_resolve_all(RecipeCreatingUnit):
 
 class Test_setup_vn_mtx_case(unittest.TestCase):
     def test_perl_case(self):
-        config = setup_vn_mtx_case([('perl', '9.10.11.12'), ('numpy', '1.23'),
-                                    ('python', '2.7'), ('r', '4.5.6')])
-        self.assertEqual(config.CONDA_PERL, '9.10.11.12')
-        self.assertEqual(config.CONDA_NPY, 123)
-        self.assertEqual(config.CONDA_PY, 27)
-        self.assertEqual(config.CONDA_R, '4.5.6')
+        if hasattr(conda_build, 'api'):
+            config = setup_vn_mtx_case([('perl', '9.10.11.12'), ('numpy', '1.23'),
+                                        ('python', '2.7'), ('r', '4.5.6')],
+                                       conda_build.api.Config())
+            self.assertEqual(config.CONDA_PERL, '9.10.11.12')
+            self.assertEqual(config.CONDA_NPY, 123)
+            self.assertEqual(config.CONDA_PY, 27)
+            self.assertEqual(config.CONDA_R, '4.5.6')
+        else:
+            with setup_vn_mtx_case([('perl', '9.10.11.12'), ('numpy', '1.23'),
+                                        ('python', '2.7'), ('r', '4.5.6')]):
+                config = conda_build.config.config
+                self.assertEqual(config.CONDA_PERL, '9.10.11.12')
+                self.assertEqual(config.CONDA_NPY, 123)
+                self.assertEqual(config.CONDA_PY, 27)
+                self.assertEqual(config.CONDA_R, '4.5.6')
+
+
 
 
 if __name__ == '__main__':

--- a/conda_build_all/version_matrix.py
+++ b/conda_build_all/version_matrix.py
@@ -7,7 +7,10 @@ from conda.resolve import MatchSpec
 from conda.resolve import stdoutlog
 from conda.console import SysStdoutWriteHandler
 
-import conda_build.api
+try:
+    import conda_build.api
+except ImportError:
+    import conda_build.config
 
 
 conda_stdoutlog = stdoutlog
@@ -335,22 +338,48 @@ def keep_top_n_minor_versions(cases, n=2):
         if keeper:
             yield case
 
+if hasattr(conda_build, 'api'):
+    def setup_vn_mtx_case(case, config):
+        for pkg, version in case:
+            if pkg == 'python':
+                version = int(version.replace('.', ''))
+                config.CONDA_PY = version
+            elif pkg == 'numpy':
+                version = int(version.replace('.', ''))
+                config.CONDA_NPY = version
+            elif pkg == 'perl':
+                config.CONDA_PERL = version
+            elif pkg == 'r':
+                config.CONDA_R = version
+            else:
+                raise NotImplementedError('Package {} not yet implemented.'
+                                          ''.format(pkg))
+        return config
 
-def setup_vn_mtx_case(case, config=None):
-    if not config:
-        config = conda_build.api.Config()
-    for pkg, version in case:
-        if pkg == 'python':
-            version = int(version.replace('.', ''))
-            config.CONDA_PY = version
-        elif pkg == 'numpy':
-            version = int(version.replace('.', ''))
-            config.CONDA_NPY = version
-        elif pkg == 'perl':
-            config.CONDA_PERL = version
-        elif pkg == 'r':
-            config.CONDA_R = version
-        else:
-            raise NotImplementedError('Package {} not yet implemented.'
-                                      ''.format(pkg))
-    return config
+else:
+    @contextmanager
+    def setup_vn_mtx_case(case, config=None):
+        config = conda_build.config.config
+        orig_npy = conda_build.config.config.CONDA_NPY
+        orig_py = conda_build.config.config.CONDA_PY
+        orig_r = conda_build.config.config.CONDA_R
+        orig_perl = conda_build.config.config.CONDA_PERL
+        for pkg, version in case:
+            if pkg == 'python':
+                version = int(version.replace('.', ''))
+                config.CONDA_PY = version
+            elif pkg == 'numpy':
+                version = int(version.replace('.', ''))
+                config.CONDA_NPY = version
+            elif pkg == 'perl':
+                config.CONDA_PERL = version
+            elif pkg == 'r':
+                config.CONDA_R = version
+            else:
+                raise NotImplementedError('Package {} not yet implemented.'
+                                          ''.format(pkg))
+        yield
+        conda_build.config.config.CONDA_NPY = orig_npy
+        conda_build.config.config.CONDA_PY = orig_py
+        conda_build.config.config.CONDA_R = orig_r
+        conda_build.config.config.CONDA_PERL = orig_perl


### PR DESCRIPTION
I'm not sure you should merge this yet.  The biggest change that conda-build-all sees in conda-build 2.0 is the no-longer-global configuration.  This simplifies conda-build-all - you no longer need context managers to change and then revert the global state.

Quite a bit of this PR seems unnecessary to me, though.  If you want much greater flexibility, then plumbing the config through like I do here makes sense.  Otherwise, it seems like too much effort.

I am going to experiment with how much I can make conda-build 2 be backwards compatible here.  Conda-build-all can adapt this PR if you want to take advantage of the non-global config somehow, but otherwise it seems easy enough to have some global instance like there used to be, and people can use it, but they don't have to.