### PR TITLE
Use conda-build config variable when making built artefact available

### DIFF
--- a/conda_build_all/artefact_destination.py
+++ b/conda_build_all/artefact_destination.py
@@ -33,7 +33,7 @@ class ArtefactDestination(object):
     def __init__(self):
         pass
 
-    def make_available(self, meta, built_dist_path, just_built):
+    def make_available(self, meta, config, built_dist_path, just_built):
         """
         Put the built distribution on this destination.
 
@@ -41,6 +41,8 @@ class ArtefactDestination(object):
         ----------
         meta : MetaData
             The metadata of the thing to make available.
+        config
+            The conda-build configuration for the build.
         built_dist_path
             The location of the built distribution for this artefact.
         just_built : bool
@@ -58,7 +60,7 @@ class DirectoryDestination(ArtefactDestination):
         if not os.path.isdir(self.directory):
             raise IOError("The destination provided is not a directory.")
 
-    def make_available(self, meta, built_dist_path, just_built):
+    def make_available(self, meta, config, built_dist_path, just_built):
         if just_built:
             print(meta, built_dist_path, just_built)
             shutil.copy(built_dist_path, self.directory)
@@ -87,7 +89,7 @@ class AnacondaClientChannelDest(ArtefactDestination):
             owner, channel = spec, 'main'
         return cls(token, owner, channel)
 
-    def make_available(self, meta, built_dist_path, just_built):
+    def make_available(self, meta, config, built_dist_path, just_built):
         if self._cli is None:
             self._cli = binstar_client.utils.get_binstar(Namespace(token=self.token, site=None))
 
@@ -112,7 +114,7 @@ class AnacondaClientChannelDest(ArtefactDestination):
         elif just_built:
             # Upload the distribution
             log.info('Uploading {} to the {} channel.'.format(meta.name(), self.channel))
-            build.upload(self._cli, meta, self.owner, channels=[self.channel])
+            build.upload(self._cli, meta, config, self.owner, channels=[self.channel])
 
         elif not just_built:
             # The distribution already existed, but not under the target owner.

--- a/conda_build_all/artefact_destination.py
+++ b/conda_build_all/artefact_destination.py
@@ -33,7 +33,7 @@ class ArtefactDestination(object):
     def __init__(self):
         pass
 
-    def make_available(self, meta, config, built_dist_path, just_built):
+    def make_available(self, meta, built_dist_path, just_built, config=None):
         """
         Put the built distribution on this destination.
 
@@ -41,12 +41,12 @@ class ArtefactDestination(object):
         ----------
         meta : MetaData
             The metadata of the thing to make available.
-        config
-            The conda-build configuration for the build.
         built_dist_path
             The location of the built distribution for this artefact.
         just_built : bool
             Whether this artefact was just built, or was already available.
+        config
+            The conda-build configuration for the build.
 
         """
         pass
@@ -60,7 +60,7 @@ class DirectoryDestination(ArtefactDestination):
         if not os.path.isdir(self.directory):
             raise IOError("The destination provided is not a directory.")
 
-    def make_available(self, meta, config, built_dist_path, just_built):
+    def make_available(self, meta, built_dist_path, just_built, config=None):
         if just_built:
             print(meta, built_dist_path, just_built)
             shutil.copy(built_dist_path, self.directory)
@@ -89,7 +89,7 @@ class AnacondaClientChannelDest(ArtefactDestination):
             owner, channel = spec, 'main'
         return cls(token, owner, channel)
 
-    def make_available(self, meta, config, built_dist_path, just_built):
+    def make_available(self, meta, built_dist_path, just_built, config=None):
         if self._cli is None:
             self._cli = binstar_client.utils.get_binstar(Namespace(token=self.token, site=None))
 
@@ -114,7 +114,8 @@ class AnacondaClientChannelDest(ArtefactDestination):
         elif just_built:
             # Upload the distribution
             log.info('Uploading {} to the {} channel.'.format(meta.name(), self.channel))
-            build.upload(self._cli, meta, config, self.owner, channels=[self.channel])
+            build.upload(self._cli, meta, self.owner, channels=[self.channel],
+                         config=config)
 
         elif not just_built:
             # The distribution already existed, but not under the target owner.

--- a/conda_build_all/build.py
+++ b/conda_build_all/build.py
@@ -37,7 +37,7 @@ def build(meta, test=True):
         return meta
 
 
-def upload(cli, meta, config, owner, channels=['main']):
+def upload(cli, meta, owner, channels=['main'], config=None):
     """Upload a distribution, given the build metadata."""
     fname = bldpkg_path(meta, config)
     package_type = detect_package_type(fname)

--- a/conda_build_all/build.py
+++ b/conda_build_all/build.py
@@ -37,9 +37,9 @@ def build(meta, test=True):
         return meta
 
 
-def upload(cli, meta, owner, channels=['main']):
+def upload(cli, meta, config, owner, channels=['main']):
     """Upload a distribution, given the build metadata."""
-    fname = bldpkg_path(meta)
+    fname = bldpkg_path(meta, config)
     package_type = detect_package_type(fname)
     package_attrs, release_attrs, file_attrs = get_attrs(package_type, fname)
     package_name = package_attrs['name']

--- a/conda_build_all/builder.py
+++ b/conda_build_all/builder.py
@@ -227,7 +227,7 @@ class Builder(object):
         return all_distros
 
     def main(self):
-        index = get_index(use_cache=True)
+        index = get_index(use_cache=False)
         if hasattr(conda_build, 'api'):
             build_config = conda_build.api.Config()
         else:

--- a/conda_build_all/builder.py
+++ b/conda_build_all/builder.py
@@ -261,9 +261,10 @@ class Builder(object):
             was_built = built_dist_location is None
             if was_built:
                 built_dist_location = self.build(meta, build_config)
-            self.post_build(meta, built_dist_location, was_built)
+            self.post_build(meta, built_dist_location, was_built,
+                            config=build_config)
 
-    def post_build(self, meta, config, built_dist_location, was_built):
+    def post_build(self, meta, built_dist_location, was_built, config=None):
         """
         The post build phase occurs whether or not a build has actually taken place.
         It is the point at which a distribution is transfered to the desired artefact
@@ -275,7 +276,10 @@ class Builder(object):
             The distribution for which we are running the post-build phase
         build_dist_location : str
             The location of the built .tar.bz2 file for the given meta.
+        config
+            The conda-build configuration for the build.
 
         """
         for artefact_destination in self.artefact_destinations:
-            artefact_destination.make_available(meta, config, built_dist_location, was_built)
+            artefact_destination.make_available(meta, built_dist_location, was_built,
+                                                config=config)

--- a/conda_build_all/builder.py
+++ b/conda_build_all/builder.py
@@ -263,7 +263,7 @@ class Builder(object):
                 built_dist_location = self.build(meta, build_config)
             self.post_build(meta, built_dist_location, was_built)
 
-    def post_build(self, meta, built_dist_location, was_built):
+    def post_build(self, meta, config, built_dist_location, was_built):
         """
         The post build phase occurs whether or not a build has actually taken place.
         It is the point at which a distribution is transfered to the desired artefact
@@ -278,4 +278,4 @@ class Builder(object):
 
         """
         for artefact_destination in self.artefact_destinations:
-            artefact_destination.make_available(meta, built_dist_location, was_built)
+            artefact_destination.make_available(meta, config, built_dist_location, was_built)

--- a/conda_build_all/tests/integration/test_inspect_binstar.py
+++ b/conda_build_all/tests/integration/test_inspect_binstar.py
@@ -3,6 +3,10 @@ import unittest
 
 from binstar_client.utils import get_binstar
 from argparse import Namespace
+try:
+    import conda_build.api
+except ImportError:
+    import conda_build.config
 
 from conda_build_all.build import build, upload
 from conda_build_all.inspect_binstar import (distribution_exists,
@@ -57,12 +61,16 @@ class Test(RecipeCreatingUnit):
                         script: echo "v0.1.0.dev1" > __conda_version__.txt
                     """)
         meta = build(meta)
+        if hasattr(conda_build, 'api'):
+            build_config = conda_build.api.Config()
+        else:
+            build_config = conda_build.config.config
 
         # Check distribution exists returns false when there is no distribution.
         self.assertFalse(distribution_exists(CLIENT, OWNER, meta))
 
         # upload the distribution 
-        upload(CLIENT, meta, OWNER, channels=['testing'])
+        upload(CLIENT, meta, build_config, OWNER, channels=['testing'])
 
         # Check the distribution exists. Notice there is no channel being supplied here.
         self.assertTrue(distribution_exists(CLIENT, OWNER, meta))

--- a/conda_build_all/tests/integration/test_inspect_binstar.py
+++ b/conda_build_all/tests/integration/test_inspect_binstar.py
@@ -70,7 +70,7 @@ class Test(RecipeCreatingUnit):
         self.assertFalse(distribution_exists(CLIENT, OWNER, meta))
 
         # upload the distribution 
-        upload(CLIENT, meta, build_config, OWNER, channels=['testing'])
+        upload(CLIENT, meta, OWNER, channels=['testing'], config=build_config)
 
         # Check the distribution exists. Notice there is no channel being supplied here.
         self.assertTrue(distribution_exists(CLIENT, OWNER, meta))

--- a/conda_build_all/tests/unit/test_artefact_destination.py
+++ b/conda_build_all/tests/unit/test_artefact_destination.py
@@ -53,8 +53,8 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
         config = self._get_config()
         with self.dist_exists_setup(on_owner=True, on_channel=False):
             with mock.patch('conda_build_all.inspect_binstar.add_distribution_to_channel') as add_to_channel:
-                ad.make_available(meta, config, mock.sentinel.dist_path,
-                                  just_built=False)
+                ad.make_available(meta, mock.sentinel.dist_path,
+                                  just_built=False, config=config)
         add_to_channel.assert_called_once_with(client, owner, meta, channel=channel)
         self.logger.info.assert_called_once_with('Adding existing a-0.0-0 to the sentinel.owner/sentinel.channel channel.')
 
@@ -67,10 +67,10 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
         config = self._get_config()
         with self.dist_exists_setup(on_owner=False, on_channel=False):
             with mock.patch('conda_build_all.build.upload') as upload:
-                ad.make_available(meta, config, mock.sentinel.dist_path,
-                                  just_built=True)
-        upload.assert_called_once_with(client, meta, config, owner,
-                                       channels=[channel])
+                ad.make_available(meta, mock.sentinel.dist_path,
+                                  just_built=True, config=config)
+        upload.assert_called_once_with(client, meta, owner,
+                                       channels=[channel], config=config)
         self.logger.info.assert_called_once_with('Uploading a to the sentinel.channel channel.')
 
     def test_already_available_not_just_built(self):
@@ -83,8 +83,8 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
         config = self._get_config()
         with self.dist_exists_setup(on_owner=True, on_channel=True):
             with mock.patch('binstar_client.utils.get_binstar') as get_binstar:
-                ad.make_available(meta, config, mock.sentinel.dist_path,
-                                  just_built=False)
+                ad.make_available(meta, mock.sentinel.dist_path,
+                                  just_built=False, config=config)
         get_binstar.assert_called_once_with(Namespace(site=None, token=mock.sentinel.token))
         # Nothing happens, we just get a message.
         self.logger.info.assert_called_once_with('Nothing to be done for a - it is already on sentinel.owner/sentinel.channel.')
@@ -97,8 +97,8 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
         meta = DummyPackage('a', '2.1.0')
         config = self._get_config()
         with self.dist_exists_setup(on_owner=True, on_channel=True):
-            ad.make_available(meta, config, mock.sentinel.dist_path,
-                              just_built=True)
+            ad.make_available(meta, mock.sentinel.dist_path,
+                              just_built=True, config=config)
         # Nothing happens, we just get a message.
         self.logger.warn.assert_called_once_with("Assuming the distribution we've just built and the one on sentinel.owner/sentinel.channel are the same.")
 
@@ -116,7 +116,8 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
                     'https://foo.bar/wibble/{}/osx-64'.format(source_owner)]:
             with self.dist_exists_setup(on_owner=False, on_channel=False):
                 with mock.patch('conda_build_all.inspect_binstar.copy_distribution_to_owner') as copy:
-                    ad.make_available(meta, config, url, just_built=False)
+                    ad.make_available(meta, url, just_built=False,
+                                      config=config)
             copy.assert_called_once_with(ad._cli, source_owner, owner, meta, channel=channel)
 
     def test_from_spec_owner(self):
@@ -146,17 +147,17 @@ class Test_DirectoryDestination(unittest.TestCase):
     def test_not_copying(self):
         dd = DirectoryDestination(self.tmp_dir)
         dd.make_available(mock.sentinel.dummy_meta,
-                          mock.sentinel.dummy_config,
                           mock.sentinel.dummy_path,
-                          just_built=False)
+                          just_built=False,
+                          config=mock.sentinel.dummy_config)
 
     def test_copying(self):
         dd = DirectoryDestination(self.tmp_dir)
         with mock.patch('shutil.copy') as copy:
             dd.make_available(mock.sentinel.dummy_meta,
-                              mock.sentinel.dummy_config,
                               mock.sentinel.dummy_path,
-                              just_built=True)
+                              just_built=True,
+                              config=mock.sentinel.dummy_config)
         copy.assert_called_once_with(mock.sentinel.dummy_path, self.tmp_dir)
 
 

--- a/conda_build_all/tests/unit/test_artefact_destination.py
+++ b/conda_build_all/tests/unit/test_artefact_destination.py
@@ -69,7 +69,8 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
             with mock.patch('conda_build_all.build.upload') as upload:
                 ad.make_available(meta, config, mock.sentinel.dist_path,
                                   just_built=True)
-        upload.assert_called_once_with(client, meta, owner, channels=[channel])
+        upload.assert_called_once_with(client, meta, config, owner,
+                                       channels=[channel])
         self.logger.info.assert_called_once_with('Uploading a to the sentinel.channel channel.')
 
     def test_already_available_not_just_built(self):

--- a/conda_build_all/tests/unit/test_artefact_destination.py
+++ b/conda_build_all/tests/unit/test_artefact_destination.py
@@ -30,6 +30,12 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
     def tearDown(self):
         self.logger_patch.stop()
 
+    def _get_config(self):
+        # Provide an object that will behave like a conda_build config object.
+        config = mock.Mock()
+        config.bldpkgs_dir = mock.Mock(return_value='')
+        return config
+
     @contextmanager
     def dist_exists_setup(self, on_owner, on_channel):
         dist_exists = mock.patch('conda_build_all.inspect_binstar.distribution_exists', return_value=on_owner)
@@ -44,9 +50,10 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
         ad = AnacondaClientChannelDest(mock.sentinel.token, owner, channel)
         ad._cli = client
         meta = DummyPackage('a', '2.1.0')
+        config = self._get_config()
         with self.dist_exists_setup(on_owner=True, on_channel=False):
             with mock.patch('conda_build_all.inspect_binstar.add_distribution_to_channel') as add_to_channel:
-                ad.make_available(meta, mock.sentinel.dist_path,
+                ad.make_available(meta, config, mock.sentinel.dist_path,
                                   just_built=False)
         add_to_channel.assert_called_once_with(client, owner, meta, channel=channel)
         self.logger.info.assert_called_once_with('Adding existing a-0.0-0 to the sentinel.owner/sentinel.channel channel.')
@@ -57,9 +64,10 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
         ad = AnacondaClientChannelDest(mock.sentinel.token, owner, channel)
         ad._cli = client
         meta = DummyPackage('a', '2.1.0')
+        config = self._get_config()
         with self.dist_exists_setup(on_owner=False, on_channel=False):
             with mock.patch('conda_build_all.build.upload') as upload:
-                ad.make_available(meta, mock.sentinel.dist_path,
+                ad.make_available(meta, config, mock.sentinel.dist_path,
                                   just_built=True)
         upload.assert_called_once_with(client, meta, owner, channels=[channel])
         self.logger.info.assert_called_once_with('Uploading a to the sentinel.channel channel.')
@@ -71,9 +79,11 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
                                   mock.sentinel.channel]
         ad = AnacondaClientChannelDest(mock.sentinel.token, owner, channel)
         meta = DummyPackage('a', '2.1.0')
+        config = self._get_config()
         with self.dist_exists_setup(on_owner=True, on_channel=True):
             with mock.patch('binstar_client.utils.get_binstar') as get_binstar:
-                ad.make_available(meta, mock.sentinel.dist_path, just_built=False)
+                ad.make_available(meta, config, mock.sentinel.dist_path,
+                                  just_built=False)
         get_binstar.assert_called_once_with(Namespace(site=None, token=mock.sentinel.token))
         # Nothing happens, we just get a message.
         self.logger.info.assert_called_once_with('Nothing to be done for a - it is already on sentinel.owner/sentinel.channel.')
@@ -84,8 +94,10 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
         ad = AnacondaClientChannelDest(mock.sentinel.token, owner, channel)
         ad._cli = client
         meta = DummyPackage('a', '2.1.0')
+        config = self._get_config()
         with self.dist_exists_setup(on_owner=True, on_channel=True):
-            ad.make_available(meta, mock.sentinel.dist_path, just_built=True)
+            ad.make_available(meta, config, mock.sentinel.dist_path,
+                              just_built=True)
         # Nothing happens, we just get a message.
         self.logger.warn.assert_called_once_with("Assuming the distribution we've just built and the one on sentinel.owner/sentinel.channel are the same.")
 
@@ -95,6 +107,7 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
         ad = AnacondaClientChannelDest(mock.sentinel.token, owner, channel)
         ad._cli = client
         meta = DummyPackage('a', '2.1.0')
+        config = self._get_config()
         source_owner = 'fake_owner'
         # The osx-64 subdirectory at the end of the URL is not important to the test.
         for url in ['http://foo.bar/{}/osx-64/'.format(source_owner),
@@ -102,7 +115,7 @@ class Test_AnacondaClientChannelDest(unittest.TestCase):
                     'https://foo.bar/wibble/{}/osx-64'.format(source_owner)]:
             with self.dist_exists_setup(on_owner=False, on_channel=False):
                 with mock.patch('conda_build_all.inspect_binstar.copy_distribution_to_owner') as copy:
-                    ad.make_available(meta, url, just_built=False)
+                    ad.make_available(meta, config, url, just_built=False)
             copy.assert_called_once_with(ad._cli, source_owner, owner, meta, channel=channel)
 
     def test_from_spec_owner(self):
@@ -131,13 +144,17 @@ class Test_DirectoryDestination(unittest.TestCase):
 
     def test_not_copying(self):
         dd = DirectoryDestination(self.tmp_dir)
-        dd.make_available(mock.sentinel.dummy_meta, mock.sentinel.dummy_path,
+        dd.make_available(mock.sentinel.dummy_meta,
+                          mock.sentinel.dummy_config,
+                          mock.sentinel.dummy_path,
                           just_built=False)
 
     def test_copying(self):
         dd = DirectoryDestination(self.tmp_dir)
         with mock.patch('shutil.copy') as copy:
-            dd.make_available(mock.sentinel.dummy_meta, mock.sentinel.dummy_path,
+            dd.make_available(mock.sentinel.dummy_meta,
+                              mock.sentinel.dummy_config,
+                              mock.sentinel.dummy_path,
                               just_built=True)
         copy.assert_called_once_with(mock.sentinel.dummy_path, self.tmp_dir)
 


### PR DESCRIPTION
Addresses a problem introduced with `conda-build-all` caused by a recent update to `conda-build`, which meant the config was needed by the built artefact uploader.