### PR TITLE
Test `get_output_file_path`

### DIFF
--- a/conda_build_all/build.py
+++ b/conda_build_all/build.py
@@ -9,7 +9,12 @@ import conda_build.build as build_module
 from conda_build.metadata import MetaData
 import conda_build.config
 from conda.lock import Locked
-from conda_build.build import bldpkg_path
+
+try:
+    from conda_build.api import get_output_file_path
+except ImportError:
+    from conda_build.build import bldpkg_path as get_output_file_path
+
 import conda_build.source
 import binstar_client
 from binstar_client.utils.detect import detect_package_type, get_attrs
@@ -39,10 +44,7 @@ def build(meta, test=True):
 
 def upload(cli, meta, owner, channels=['main'], config=None):
     """Upload a distribution, given the build metadata."""
-    if hasattr(conda_build, 'api'):
-        fname = bldpkg_path(meta, config)
-    else:
-        fname = bldpkg_path(meta)
+    fname = get_output_file_path(meta)
     package_type = detect_package_type(fname)
     package_attrs, release_attrs, file_attrs = get_attrs(package_type, fname)
     package_name = package_attrs['name']

--- a/conda_build_all/tests/integration/test_builder.py
+++ b/conda_build_all/tests/integration/test_builder.py
@@ -216,7 +216,7 @@ class Test_compute_build_distros(RecipeCreatingUnit):
                     'my_py_package-2.0-py35_0']
         self.assertEqual([meta.dist() for meta in distributions], expected)
         # Check that we didn't change the index.
-        self.assertEqual(index, {}) 
+        self.assertEqual(index, {})
 
 
 if __name__ == '__main__':

--- a/conda_build_all/tests/unit/dummy_index.py
+++ b/conda_build_all/tests/unit/dummy_index.py
@@ -4,6 +4,7 @@ import os
 from conda_build.index import write_repodata
 try:
     import conda_build.api
+    from conda_build.utils import get_lock
     extra_config = False
 except ImportError:
     import conda_build
@@ -70,7 +71,8 @@ class DummyIndex(dict):
         if not os.path.exists(channel_subdir):
             os.mkdir(channel_subdir)
         if hasattr(conda_build, 'api'):
-            write_repodata({'packages': self, 'info': {}}, channel_subdir, conda_build.api.Config())
+            lock = get_lock(channel_subdir)
+            write_repodata({'packages': self, 'info': {}}, channel_subdir, lock, config=conda_build.api.Config())
         else:
             write_repodata({'packages': self, 'info': {}}, channel_subdir)
 


### PR DESCRIPTION
Yet another attempt to fix `bldpkg_path` for all conda-build versions.

See https://github.com/SciTools/conda-build-all/pull/68/files#r93306331