### PR TITLE
Use `r-base` to determine R version(s)

### DIFF
--- a/conda_build_all/tests/unit/test_resolved_distribution.py
+++ b/conda_build_all/tests/unit/test_resolved_distribution.py
@@ -111,7 +111,7 @@ class Test_setup_vn_mtx_case(unittest.TestCase):
     def test_perl_case(self):
         if hasattr(conda_build, 'api'):
             config = setup_vn_mtx_case([('perl', '9.10.11.12'), ('numpy', '1.23'),
-                                        ('python', '2.7'), ('r', '4.5.6')],
+                                        ('python', '2.7'), ('r-base', '4.5.6')],
                                        conda_build.api.Config())
             self.assertEqual(config.CONDA_PERL, '9.10.11.12')
             self.assertEqual(config.CONDA_NPY, 123)
@@ -119,7 +119,7 @@ class Test_setup_vn_mtx_case(unittest.TestCase):
             self.assertEqual(config.CONDA_R, '4.5.6')
         else:
             with setup_vn_mtx_case([('perl', '9.10.11.12'), ('numpy', '1.23'),
-                                        ('python', '2.7'), ('r', '4.5.6')]):
+                                        ('python', '2.7'), ('r-base', '4.5.6')]):
                 config = conda_build.config.config
                 self.assertEqual(config.CONDA_PERL, '9.10.11.12')
                 self.assertEqual(config.CONDA_NPY, 123)

--- a/conda_build_all/tests/unit/test_version_matrix.py
+++ b/conda_build_all/tests/unit/test_version_matrix.py
@@ -239,33 +239,33 @@ class Test_special_case_version_matrix(unittest.TestCase):
         self.assertEqual(r, expected)
 
     def test_r_matrix(self):
-        a = DummyPackage('pkgA', ['r'])
-        self.index.add_pkg('r', '4.5.6')
-        self.index.add_pkg('r', '4.5.7')
+        a = DummyPackage('pkgA', ['r-base'])
+        self.index.add_pkg('r-base', '4.5.6')
+        self.index.add_pkg('r-base', '4.5.7')
         r = special_case_version_matrix(a, self.index)
-        self.assertEqual(r, set(((('r', '4.5.6'),),
-                                 (('r', '4.5.7'),),
+        self.assertEqual(r, set(((('r-base', '4.5.6'),),
+                                 (('r-base', '4.5.7'),),
                                 ))
                          )
 
     def test_r_and_py_and_perl_matrix(self):
-        a = DummyPackage('pkgA', ['perl', 'python', 'r'])
+        a = DummyPackage('pkgA', ['perl', 'python', 'r-base'])
         self.index.add_pkg('perl', '4.5.6')
         self.index.add_pkg('perl', '4.5.7')
         self.index.add_pkg('python', '2.7')
         self.index.add_pkg('python', '3.5')
-        self.index.add_pkg('r', '1.2.3')
-        self.index.add_pkg('r', '4.5.6')
+        self.index.add_pkg('r-base', '1.2.3')
+        self.index.add_pkg('r-base', '4.5.6')
 
         r = special_case_version_matrix(a, self.index)
-        expected = set(((('python', '2.7'), ('perl', '4.5.6'), ('r', '1.2.3')),
-                        (('python', '2.7'), ('perl', '4.5.6'), ('r', '4.5.6')),
-                        (('python', '3.5'), ('perl', '4.5.6'), ('r', '1.2.3')),
-                        (('python', '3.5'), ('perl', '4.5.7'), ('r', '1.2.3')),
-                        (('python', '3.5'), ('perl', '4.5.7'), ('r', '4.5.6')),
-                        (('python', '2.7'), ('perl', '4.5.7'), ('r', '4.5.6')),
-                        (('python', '2.7'), ('perl', '4.5.7'), ('r', '1.2.3')),
-                        (('python', '3.5'), ('perl', '4.5.6'), ('r', '4.5.6')),
+        expected = set(((('python', '2.7'), ('perl', '4.5.6'), ('r-base', '1.2.3')),
+                        (('python', '2.7'), ('perl', '4.5.6'), ('r-base', '4.5.6')),
+                        (('python', '3.5'), ('perl', '4.5.6'), ('r-base', '1.2.3')),
+                        (('python', '3.5'), ('perl', '4.5.7'), ('r-base', '1.2.3')),
+                        (('python', '3.5'), ('perl', '4.5.7'), ('r-base', '4.5.6')),
+                        (('python', '2.7'), ('perl', '4.5.7'), ('r-base', '4.5.6')),
+                        (('python', '2.7'), ('perl', '4.5.7'), ('r-base', '1.2.3')),
+                        (('python', '3.5'), ('perl', '4.5.6'), ('r-base', '4.5.6')),
                         ))
         self.assertEqual(r, expected)
 

--- a/conda_build_all/version_matrix.py
+++ b/conda_build_all/version_matrix.py
@@ -223,12 +223,12 @@ def special_case_version_matrix(meta, index):
                 if case_base in cases:
                     cases.remove(case_base)
 
-        if 'r' in requirement_specs:
-            r_spec = requirement_specs.pop('r')
+        if 'r-base' in requirement_specs:
+            r_spec = requirement_specs.pop('r-base')
             for case_base in list(cases or [()]):
                 for r_pkg in r.get_pkgs(r_spec):
                     r_vn = index[r_pkg.fn]['version']
-                    case = case_base + (('r', r_vn), )
+                    case = case_base + (('r-base', r_vn), )
                     add_case_if_soluble(case)
                 if case_base in cases:
                     cases.remove(case_base)
@@ -344,7 +344,7 @@ if hasattr(conda_build, 'api'):
                 config.CONDA_NPY = version
             elif pkg == 'perl':
                 config.CONDA_PERL = version
-            elif pkg == 'r':
+            elif pkg == 'r-base':
                 config.CONDA_R = version
             else:
                 raise NotImplementedError('Package {} not yet implemented.'
@@ -368,7 +368,7 @@ else:
                 config.CONDA_NPY = version
             elif pkg == 'perl':
                 config.CONDA_PERL = version
-            elif pkg == 'r':
+            elif pkg == 'r-base':
                 config.CONDA_R = version
             else:
                 raise NotImplementedError('Package {} not yet implemented.'


### PR DESCRIPTION
Fixes https://github.com/SciTools/conda-build-all/issues/73

Use `r-base` (not `r`) for determining when to fill in `CONDA_R`.

cc @johanneskoester @mingwandroid