### PR TITLE
Handle all cases of missing packages when building version matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
       fi 
 
     # Now do the things we need to do to install it.
-    - conda install --file requirements.txt nose mock python=${PYTHON} ${EXTRA_DEPS} --yes --quiet
+    - conda install -c conda-forge --file requirements.txt nose mock python=${PYTHON} ${EXTRA_DEPS} --yes --quiet
     - python setup.py install
     - mkdir not_the_source_root && cd not_the_source_root
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ conda >=4
 conda-build >=1.21.7
 anaconda-client
 mock
+requests==2.11 # work around conda/conda#3947


### PR DESCRIPTION
So far, when creating a version matrix, conda-build-all only skipped cases where a specific version was missing or infeasible. This PR fixes a crash when a particular package was not available at all for a certain platform, see conda-forge/conda-smithy#488.

Further, I have fixed the failing test cases, by taking updated conda versions from conda-forge and pinning to requests-2.11 (see conda/conda#3947).